### PR TITLE
AES-GCM auth tag verification

### DIFF
--- a/src/dlms_parser/apdu_handler.cpp
+++ b/src/dlms_parser/apdu_handler.cpp
@@ -166,9 +166,24 @@ ApduHandler::UnwrapResult ApduHandler::unwrap_in_place(uint8_t* buf, size_t len)
       const uint32_t payload_len = cipher_len - DLMS_LENGTH_CORRECTION - tag_len;
       if (pos + payload_len + tag_len > len) return {0, 0};
 
-      // Decrypt ciphertext only (GCM tag excluded)
-      if (!this->decryptor_->decrypt_in_place(iv, std::span(buf + pos, payload_len))) {
-        Logger::log(LogLevel::ERROR, "Decryption failed");
+      // Build AAD and tag spans for GCM.
+      // AAD = security_control(1) + authentication_key(16), per DLMS Green Book.
+      // Tag verification only happens when auth bit is set AND auth key is provided.
+      uint8_t aad[17];
+      size_t aad_len = 0;
+      std::span<const uint8_t> gcm_tag;
+
+      if (has_auth_tag && this->decryptor_->has_auth_key()) {
+        aad[0] = security_control;
+        std::memcpy(aad + 1, this->decryptor_->auth_key_data(), 16);
+        aad_len = 17;
+        gcm_tag = std::span<const uint8_t>(buf + pos + payload_len, DLMS_GCM_TAG_LENGTH);
+      }
+
+      if (!this->decryptor_->decrypt_in_place(
+              iv, std::span(buf + pos, payload_len),
+              std::span<const uint8_t>(aad, aad_len), gcm_tag)) {
+        Logger::log(LogLevel::ERROR, "Decryption failed (auth tag mismatch?)");
         return {0, 0};
       }
       std::memmove(buf, buf + pos, payload_len);

--- a/src/dlms_parser/decryption/aes_128_gcm_decryptor.h
+++ b/src/dlms_parser/decryption/aes_128_gcm_decryptor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <optional>
 #include <array>
 #include <span>
@@ -26,14 +27,33 @@ private:
 class Aes128GcmDecryptor {
  public:
   virtual void set_decryption_key(const Aes128GcmDecryptionKey& key) = 0;
-  virtual bool decrypt_in_place(std::span<uint8_t> iv, std::span<uint8_t> cipher) = 0;
-  [[nodiscard]] bool has_key() const { return _has_key; }
+
+  virtual void set_authentication_key(const Aes128GcmDecryptionKey& key) {
+    std::memcpy(auth_key_.data(), key.data(), 16);
+    has_auth_key_ = true;
+  }
+
+  // Decrypt cipher in-place.
+  // When aad + tag are non-empty, verifies the GCM authentication tag.
+  // aad = security_control(1) + authentication_key(16), per DLMS Green Book.
+  virtual bool decrypt_in_place(std::span<uint8_t> iv,
+                                std::span<uint8_t> cipher,
+                                std::span<const uint8_t> aad,
+                                std::span<const uint8_t> tag) = 0;
+
+  [[nodiscard]] bool has_key() const { return has_decryption_key_; }
+  [[nodiscard]] bool has_auth_key() const { return has_auth_key_ && !skip_auth_; }
+  [[nodiscard]] const uint8_t* auth_key_data() const { return auth_key_.data(); }
+  void set_skip_auth_check(bool skip) { skip_auth_ = skip; }
 
   virtual ~Aes128GcmDecryptor() = default;
 
  protected:
   Aes128GcmDecryptor() = default;
-  bool _has_key = false;
+  bool has_decryption_key_ = false;
+  bool has_auth_key_ = false;
+  bool skip_auth_ = false;
+  std::array<uint8_t, 16> auth_key_{};
 };
 
 }

--- a/src/dlms_parser/decryption/aes_128_gcm_decryptor_bearssl.h
+++ b/src/dlms_parser/decryption/aes_128_gcm_decryptor_bearssl.h
@@ -12,19 +12,29 @@ class Aes128GcmDecryptorBearSsl : public Aes128GcmDecryptor, NonCopyableAndNonMo
 
  public:
   Aes128GcmDecryptorBearSsl() = default;
-  
+
   void set_decryption_key(const Aes128GcmDecryptionKey& key) override {
     br_aes_ct_ctr_init(&aes, key.data(), 16);
     br_gcm_init(&gcm, &aes.vtable, br_ghash_ctmul32);
-    _has_key = true;
+    has_decryption_key_ = true;
   }
-  
-  bool decrypt_in_place(const std::span<uint8_t> iv, std::span<uint8_t> cipher) override {
-    if (!_has_key) { return false; }
+
+  bool decrypt_in_place(std::span<uint8_t> iv,
+                        std::span<uint8_t> cipher,
+                        std::span<const uint8_t> aad,
+                        std::span<const uint8_t> tag) override {
+    if (!has_decryption_key_) { return false; }
 
     br_gcm_reset(&gcm, iv.data(), iv.size());
+    if (!aad.empty()) {
+      br_gcm_aad_inject(&gcm, aad.data(), aad.size());
+    }
     br_gcm_flip(&gcm);
     br_gcm_run(&gcm, 0, cipher.data(), cipher.size());
+
+    if (!tag.empty()) {
+      return br_gcm_check_tag_trunc(&gcm, tag.data(), tag.size()) == 1;
+    }
     return true;
   }
 };

--- a/src/dlms_parser/decryption/aes_128_gcm_decryptor_mbedtls.h
+++ b/src/dlms_parser/decryption/aes_128_gcm_decryptor_mbedtls.h
@@ -14,13 +14,30 @@ public:
   ~Aes128GcmDecryptorMbedTls() override { mbedtls_gcm_free(&gcm); }
 
   void set_decryption_key(const Aes128GcmDecryptionKey& key) override {
-    _has_key = mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, key.data(), 128) == 0;
+    has_decryption_key_ = mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, key.data(), 128) == 0;
   }
 
-  bool decrypt_in_place(const std::span<uint8_t> iv, std::span<uint8_t> cipher) override {
-    if (!_has_key) { return false; }
+  bool decrypt_in_place(std::span<uint8_t> iv,
+                        std::span<uint8_t> cipher,
+                        std::span<const uint8_t> aad,
+                        std::span<const uint8_t> tag) override {
+    if (!has_decryption_key_) { return false; }
 
-    unsigned char tag[12]; // dummy tag to satisfy the API
+    if (!tag.empty()) {
+      // Authenticated: decrypt and verify tag in one call
+      return mbedtls_gcm_auth_decrypt(/* ctx     */ &gcm,
+                                      /* length  */ cipher.size(),
+                                      /* iv      */ iv.data(),
+                                      /* iv_len  */ iv.size(),
+                                      /* aad     */ aad.data(),
+                                      /* aad_len */ aad.size(),
+                                      /* tag     */ tag.data(),
+                                      /* tag_len */ tag.size(),
+                                      /* input   */ cipher.data(),
+                                      /* output  */ cipher.data()) == 0;
+    }
+    // Encrypt-only: no tag verification, no AAD
+    unsigned char dummy_tag[12];
     return mbedtls_gcm_crypt_and_tag(/* ctx     */ &gcm,
                                      /* mode    */ MBEDTLS_GCM_DECRYPT,
                                      /* length  */ cipher.size(),
@@ -30,8 +47,8 @@ public:
                                      /* aad_len */ 0,
                                      /* input   */ cipher.data(),
                                      /* output  */ cipher.data(),
-                                     /* tag_len */ sizeof(tag),
-                                     /* tag     */ tag) == 0;
+                                     /* tag_len */ sizeof(dummy_tag),
+                                     /* tag     */ dummy_tag) == 0;
   }
 };
 

--- a/src/dlms_parser/dlms_parser.cpp
+++ b/src/dlms_parser/dlms_parser.cpp
@@ -25,6 +25,10 @@ void DlmsParser::set_skip_crc_check(const bool skip) {
   this->mbus_decoder_.set_skip_crc_check(skip);
 }
 
+void DlmsParser::set_skip_auth_check(const bool skip) {
+  this->decryptor_.set_skip_auth_check(skip);
+}
+
 void DlmsParser::set_work_buffer(uint8_t* buf, const size_t capacity) {
   this->work_buf_ = buf;
   this->work_buf_capacity_ = capacity;
@@ -32,6 +36,10 @@ void DlmsParser::set_work_buffer(uint8_t* buf, const size_t capacity) {
 
 void DlmsParser::set_decryption_key(const Aes128GcmDecryptionKey& key) const {
   decryptor_.set_decryption_key(key);
+}
+
+void DlmsParser::set_authentication_key(const Aes128GcmDecryptionKey& key) const {
+  decryptor_.set_authentication_key(key);
 }
 
 void DlmsParser::load_default_patterns() {

--- a/src/dlms_parser/dlms_parser.h
+++ b/src/dlms_parser/dlms_parser.h
@@ -18,8 +18,10 @@ class DlmsParser final : NonCopyableAndNonMovable {
 
   void set_frame_format(const FrameFormat fmt) { this->frame_format_ = fmt; }
   void set_skip_crc_check(bool skip);
+  void set_skip_auth_check(bool skip);
   void set_work_buffer(uint8_t* buf, size_t capacity);
   void set_decryption_key(const Aes128GcmDecryptionKey& key) const;
+  void set_authentication_key(const Aes128GcmDecryptionKey& key) const;
 
   // Load built-in patterns (T1, T2, T3, U.ZPA).
   void load_default_patterns();

--- a/tests/expected/hdlc_kamstrup_omnipower.h
+++ b/tests/expected/hdlc_kamstrup_omnipower.h
@@ -52,11 +52,10 @@ const auto hdlc_kamstrup_omnipower_key = dlms_parser::Aes128GcmDecryptionKey::fr
     0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
 }).value();
 
-// Not currently consumed by the parser, but stored with the fixture for completeness.
-constexpr std::array<uint8_t, 16> hdlc_kamstrup_omnipower_auth_key = {
+const auto hdlc_kamstrup_omnipower_auth_key = dlms_parser::Aes128GcmDecryptionKey::from_bytes(std::array<uint8_t, 16>{
     0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88,
     0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00,
-};
+}).value();
 
 constexpr size_t hdlc_kamstrup_omnipower_expected_count = 33;
 

--- a/tests/test_meter_dumps.cpp
+++ b/tests/test_meter_dumps.cpp
@@ -281,8 +281,8 @@ TEST_CASE("Integration: HDLC") {
     );
   }
 
-  SUBCASE("Kamstrup Omnipower (encrypted)") {
-    run_meter_test("Kamstrup Omnipower (encrypted)",
+  SUBCASE("Kamstrup Omnipower (encrypted, no auth key)") {
+    run_meter_test("Kamstrup Omnipower (encrypted, no auth key)",
       dlms::test_data::hdlc_kamstrup_omnipower_raw_frame,
       sizeof(dlms::test_data::hdlc_kamstrup_omnipower_raw_frame),
       dlms::test_data::hdlc_kamstrup_omnipower_expected_count,
@@ -291,10 +291,44 @@ TEST_CASE("Integration: HDLC") {
       dlms_parser::FrameFormat::HDLC,
       [](dlms_parser::DlmsParser& p) {
         p.set_decryption_key(dlms::test_data::hdlc_kamstrup_omnipower_key);
-        p.register_pattern("Obis List Ver", "F, TSTR"); // OBIS List Version Identifier
+        p.register_pattern("Obis List Ver", "F, TSTR");
         p.register_pattern("Code-Value Pair", "TO, TV");
       }
     );
+  }
+
+  SUBCASE("Kamstrup Omnipower (encrypted + authenticated)") {
+    run_meter_test("Kamstrup Omnipower (encrypted + authenticated)",
+      dlms::test_data::hdlc_kamstrup_omnipower_raw_frame,
+      sizeof(dlms::test_data::hdlc_kamstrup_omnipower_raw_frame),
+      dlms::test_data::hdlc_kamstrup_omnipower_expected_count,
+      dlms::test_data::hdlc_kamstrup_omnipower_expected_strings,
+      dlms::test_data::hdlc_kamstrup_omnipower_expected_floats,
+      dlms_parser::FrameFormat::HDLC,
+      [](dlms_parser::DlmsParser& p) {
+        p.set_decryption_key(dlms::test_data::hdlc_kamstrup_omnipower_key);
+        p.set_authentication_key(dlms::test_data::hdlc_kamstrup_omnipower_auth_key);
+        p.register_pattern("Obis List Ver", "F, TSTR");
+        p.register_pattern("Code-Value Pair", "TO, TV");
+      }
+    );
+  }
+
+  SUBCASE("Kamstrup Omnipower - wrong auth key rejects frame") {
+    const auto wrong_key = dlms_parser::Aes128GcmDecryptionKey::from_bytes(std::array<uint8_t, 16>{0x00}).value();
+    std::array<uint8_t, 2048> work_buf{};
+    dlms_parser::Aes128GcmDecryptorMbedTls decryptor;
+    dlms_parser::DlmsParser parser(decryptor);
+    parser.set_work_buffer(work_buf.data(), work_buf.size());
+    parser.set_frame_format(dlms_parser::FrameFormat::HDLC);
+    parser.set_decryption_key(dlms::test_data::hdlc_kamstrup_omnipower_key);
+    parser.set_authentication_key(wrong_key);
+    parser.load_default_patterns();
+    auto [n, consumed] = parser.parse(
+      dlms::test_data::hdlc_kamstrup_omnipower_raw_frame,
+      sizeof(dlms::test_data::hdlc_kamstrup_omnipower_raw_frame),
+      [](const char*, float, const char*, bool) {});
+    CHECK(n == 0);
   }
 
 }


### PR DESCRIPTION
## Summary
- Properly separate GCM auth tag from ciphertext based on security control byte (bit 0x10)
- Add authentication key support with AAD construction per DLMS Green Book: `security_control(1) + auth_key(16)`
- Implement tag verification in both mbedTLS (`mbedtls_gcm_auth_decrypt`) and BearSSL (`br_gcm_check_tag_trunc`)
- Add `set_skip_auth_check()` to bypass tag verification when needed
