### PR TITLE
Skip the MBus short frame at the beginning of the buffer.

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,3 @@
-version: "1.2.0"
 description: "A C++20 library for parsing DLMS/COSEM push telegrams from electricity meters. It is designed for embedded and integration-heavy environments such as ESPHome"
 url: "https://github.com/esphome-libs/dlms_parser"
 files:

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "dlms_parser",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A C++20 library for parsing DLMS/COSEM push telegrams from electricity meters. It is designed for embedded and integration-heavy environments such as ESPHome",
   "keywords": [
     "dlms",

--- a/src/dlms_parser/dlms_parser.cpp
+++ b/src/dlms_parser/dlms_parser.cpp
@@ -22,6 +22,11 @@ static void log_span_as_hex(const LogLevel level, const std::span<const uint8_t>
   }
 }
 
+static bool is_mbus_short_frame(const std::span<const uint8_t> data) {
+  if (data.size() < 5 || data[0] != 0x10 || data[4] != 0x16) return false;
+  return static_cast<uint8_t>(data[1] + data[2]) == data[3];
+}
+
 DlmsParser::DlmsParser(Aes128GcmDecryptor* decryptor) : decryptor_(decryptor) {}
 
 void DlmsParser::set_skip_crc_check(const bool skip) {
@@ -71,6 +76,12 @@ ParseResult DlmsParser::parse(std::span<uint8_t> buf, const DlmsDataCallback& co
   Logger::log(LogLevel::VERY_VERBOSE, "Buffer content:");
   log_span_as_hex(LogLevel::VERY_VERBOSE, buf);
   Logger::log(LogLevel::VERY_VERBOSE, "============");
+
+  if (is_mbus_short_frame(buf)) {
+    Logger::log(LogLevel::VERBOSE, "Skipping M-Bus short frame prefix");
+    buf = buf.subspan(5);
+    if (buf.empty()) return {};
+  }
 
   std::span<uint8_t> decoded;
 

--- a/tests/test_meter_dumps.cpp
+++ b/tests/test_meter_dumps.cpp
@@ -191,6 +191,17 @@ TEST_CASE("Integration: HDLC") {
     );
   }
 
+  SUBCASE("Iskra 550 (3 segmented frames) with leading M-Bus short frame") {
+    std::vector<uint8_t> frame{0x10, 0x40, 0x01, 0x41, 0x16};
+    frame.insert(frame.end(), std::begin(dlms::test_data::iskra550_raw_frame), std::end(dlms::test_data::iskra550_raw_frame));
+    run_meter_test(
+      frame,
+      dlms::test_data::iskra550_expected_count,
+      dlms::test_data::iskra550_expected_strings,
+      dlms::test_data::iskra550_expected_floats
+    );
+  }
+
   SUBCASE("Iskra 550 (3 segmented frames) and the same data at the end. Should ignore the duplicated part") {
     std::vector<uint8_t> duplicated_frame(std::begin(dlms::test_data::iskra550_raw_frame), std::end(dlms::test_data::iskra550_raw_frame));
     duplicated_frame.insert(duplicated_frame.end(), std::begin(dlms::test_data::iskra550_raw_frame), std::end(dlms::test_data::iskra550_raw_frame));


### PR DESCRIPTION
Fix https://github.com/esphome-libs/dlms_parser/issues/16