### PR TITLE
Ignore Mbus short frames when parsing HDLC transmission

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "dlms_parser",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A C++20 library for parsing DLMS/COSEM push telegrams from electricity meters. It is designed for embedded and integration-heavy environments such as ESPHome",
   "keywords": [
     "dlms",

--- a/src/dlms_parser/dlms_parser.cpp
+++ b/src/dlms_parser/dlms_parser.cpp
@@ -22,11 +22,6 @@ static void log_span_as_hex(const LogLevel level, const std::span<const uint8_t>
   }
 }
 
-static bool is_mbus_short_frame(const std::span<const uint8_t> data) {
-  if (data.size() < 5 || data[0] != 0x10 || data[4] != 0x16) return false;
-  return static_cast<uint8_t>(data[1] + data[2]) == data[3];
-}
-
 DlmsParser::DlmsParser(DlmsDataCallback dlmsDataCallback, Aes128GcmDecryptor* decryptor) : decryptor_(decryptor), axdr_parser_(std::move(dlmsDataCallback)) {}
 
 void DlmsParser::set_skip_crc_check(const bool skip) {

--- a/src/dlms_parser/hdlc_decoder.cpp
+++ b/src/dlms_parser/hdlc_decoder.cpp
@@ -1,4 +1,5 @@
 #include "hdlc_decoder.h"
+#include "utils.h"
 #include "log.h"
 #include <algorithm>
 
@@ -62,13 +63,20 @@ static size_t address_length(const std::span<const uint8_t> p) {
 static constexpr uint8_t HDLC_FLAG    = 0x7E;
 static constexpr uint8_t HDLC_SEG_BIT = 0x08;  // bit 3 of frame-type byte: "more frames follow"
 
-std::span<uint8_t> decode_hdlc_frames_in_place(std::span<uint8_t> buf, bool skip_crc_check) {
+std::span<uint8_t> decode_hdlc_frames_in_place(std::span<uint8_t> buf, const bool skip_crc_check) {
   size_t read_offset = 0;
   size_t write_offset = 0;
   bool is_first = true;
 
   do {
     const auto remaining = buf.subspan(read_offset);
+
+    if (is_mbus_short_frame(remaining)) {
+      Logger::log(LogLevel::VERBOSE, "HDLC: skipping M-Bus short frame at offset %zu", read_offset);
+      read_offset += 5;
+      continue;
+    }
+
     if (remaining.size() < 4 || remaining[0] != HDLC_FLAG) {
       Logger::log(LogLevel::WARNING, "HDLC: invalid frame at offset %zu", read_offset);
       return {};

--- a/src/dlms_parser/hdlc_decoder.h
+++ b/src/dlms_parser/hdlc_decoder.h
@@ -16,8 +16,9 @@ namespace dlms_parser {
 // - LLC header stripped if present: {0xE6, 0xE7, 0x00} or {0xE6, 0xE6, 0x00}
 // - FCS: CRC16/IBM-SDLC over frame[1..before_FCS]
 //
-// In-place decode: extracts and concatenates payloads from all HDLC frames
-// in buf, writing them sequentially to buf[0..]. Returns a subspan of buf, empty on error.
+// In-place decode: extracts and concatenates payloads from all HDLC frames.
+// Ignores valid M-Bus short frames if they appear before, between, or after HDLC frames.
+// Returns a subspan of buf, empty on error.
 std::span<uint8_t> decode_hdlc_frames_in_place(std::span<uint8_t> buf, bool skip_crc_check = false);
 
 }

--- a/src/dlms_parser/utils.h
+++ b/src/dlms_parser/utils.h
@@ -79,4 +79,9 @@ uint32_t read_ber_length(std::span<const uint8_t> buf, size_t& pos);
 int get_data_type_size(DlmsDataType type);
 bool is_value_data_type(DlmsDataType type);
 
+inline bool is_mbus_short_frame(const std::span<const uint8_t> data) {
+  if (data.size() < 5 || data[0] != 0x10 || data[4] != 0x16) return false;
+  return static_cast<uint8_t>(data[1] + data[2]) == data[3];
+}
+
 }

--- a/tests/test_hdlc_decoder.cpp
+++ b/tests/test_hdlc_decoder.cpp
@@ -114,6 +114,39 @@ TEST_CASE_FIXTURE(LogFixture, "HDLC Decoder - Payload Decoding (decode)") {
     CHECK(multi_frame[4] == 0xEE);
   }
 
+  SUBCASE("M-Bus short frames are ignored before, between, and after HDLC frames") {
+    constexpr uint8_t mbus_short_frame[] = {0x10, 0x40, 0x01, 0x41, 0x16};
+    std::vector<uint8_t> transmission(std::begin(mbus_short_frame), std::end(mbus_short_frame));
+
+    auto frame1 = BASE_FRAME;
+    frame1.erase(frame1.begin() + 13);
+    update_frame_length(frame1, true);
+
+    std::vector<uint8_t> frame2 = {
+      0x7E, 0xA0, 0x00,
+      0x03, 0x21, 0x93,
+      0x11, 0x22,
+      0xCC, 0xDD, 0xEE,
+      0x33, 0x44,
+      0x7E
+    };
+    update_frame_length(frame2);
+
+    transmission.insert(transmission.end(), frame1.begin(), frame1.end());
+    transmission.insert(transmission.end(), std::begin(mbus_short_frame), std::end(mbus_short_frame));
+    transmission.insert(transmission.end(), std::begin(mbus_short_frame), std::end(mbus_short_frame));
+    transmission.insert(transmission.end(), frame2.begin(), frame2.end());
+    transmission.insert(transmission.end(), std::begin(mbus_short_frame), std::end(mbus_short_frame));
+
+    const auto result = decode_hdlc_frames_in_place(transmission, true);
+    REQUIRE(result.size() == 5);
+    CHECK(result[0] == 0xAA);
+    CHECK(result[1] == 0xBB);
+    CHECK(result[2] == 0xCC);
+    CHECK(result[3] == 0xDD);
+    CHECK(result[4] == 0xEE);
+  }
+
   SUBCASE("LLC stripping ONLY occurs on first frame of segmented payload") {
     std::vector<uint8_t> multi_frame;
     auto frame1 = BASE_FRAME;
@@ -224,6 +257,13 @@ TEST_CASE_FIXTURE(LogFixture, "HDLC Decoder - Address Length Decoding") {
 }
 
 TEST_CASE_FIXTURE(LogFixture, "HDLC Decoder - Malformed Frame Handling") {
+
+  SUBCASE("M-Bus short frame with invalid checksum is not ignored") {
+    std::vector<uint8_t> transmission = {0x10, 0x40, 0x01, 0x42, 0x16};
+    transmission.insert(transmission.end(), BASE_FRAME.begin(), BASE_FRAME.end());
+
+    CHECK(decode_hdlc_frames_in_place(transmission, true).empty());
+  }
 
   SUBCASE("Length field mismatch vs buffer boundaries") {
     auto frame = BASE_FRAME;


### PR DESCRIPTION
The log provided by @TheNetStriker [here](https://github.com/esphome/esphome/pull/16942#issuecomment-4968048562) shows that the `Landis+Gyr E450` smart meter sends Mbus short frames while transmitting HDLC packets

Lone Mbus packet without any HDLC packets:
```
2026-07-14T09:57:59.916Z gplugm01/debug [0;37m[V][dlms_meter:157]: Processing frame of size: 5 bytes
2026-07-14T09:57:59.961Z gplugm01/debug [0;38m[VV][dlms_meter:030]: Buffer content:
2026-07-14T09:57:59.961Z gplugm01/debug [0;38m[VV][dlms_meter:030]: 1040014116
2026-07-14T09:57:59.961Z gplugm01/debug [0;38m[VV][dlms_meter:030]: ============
2026-07-14T09:57:59.961Z gplugm01/debug [0;37m[V][dlms_meter:027]: Skipping M-Bus short frame prefix
```

Mbus short packet `107B017C16` in between the end of HDLC transmission. It later causes an error because the last HDLC packet comes after more than a second and is treated as a separate transmission (it is another issue that we need to address):
```
2026-07-14T09:58:13.782Z gplugm01/debug [0;37m[V][dlms_meter:157]: Processing frame of size: 657 bytes
2026-07-14T09:58:13.810Z gplugm01/debug [0;38m[VV][dlms_meter:030]: Buffer content:
2026-07-14T09:58:13.811Z gplugm01/debug [0;38m[VV][dlms_meter:030]: 7EA084CEFF0313128BE6E700E04000010000700F005A35950C07EA070E020B3A0AFF800000021C011C020412002809060008190900FF0F021200000204120001090600002A0000FF0F02120000020412000309060101010800FF0F021200000204120003
2026-07-14T09:58:13.811Z gplugm01/debug [0;38m[VV][dlms_meter:030]: 09060101020800FF0F02120000020412000309060101030800FF0F02120000EE6C7E7EA07DCEFF0313D045E040000200006C020412000309060101040800FF0F02120000020412000109060000600E00FF0F02120000020412000309060100010700FF0F
2026-07-14T09:58:13.811Z gplugm01/debug [0;38m[VV][dlms_meter:030]: 02120000020412000309060100020700FF0F02120000020412000309060100200700FF0F02120000020412000309060100340700FF0F02120000FEF57E7EA07DCEFF0313D045E040000300006C020412000309060100480700FF0F021200000204120003
2026-07-14T09:58:13.811Z gplugm01/debug [0;38m[VV][dlms_meter:030]: 090601001F0700FF0F02120000020412000309060100330700FF0F02120000020412000309060100470700FF0F02120000020412000309060100150700FF0F02120000020412000309060100290700FF0F02120000FB657E7EA07DCEFF0313D045E04000
2026-07-14T09:58:13.811Z gplugm01/debug [0;38m[VV][dlms_meter:030]: 0400006C0204120003090601003D0700FF0F02120000020412000309060100160700FF0F021200000204120003090601002A0700FF0F021200000204120003090601003E0700FF0F02120000020412000309060100170700FF0F02120000020412000309
2026-07-14T09:58:13.812Z gplugm01/debug [0;38m[VV][dlms_meter:030]: 0601002B0700FF0F02120000C8FF7E7EA087CEFF0313DE96E04000050000760204120003090601003F0700FF0F02120000020412000309060100180700FF0F021200000204120003090601002C0700FF0F02120000020412000309060100400700FF0F02
2026-07-14T09:58:13.865Z gplugm01/debug [0;38m[VV][dlms_meter:030]: 120000020412000109060000600D00FF0F0212000009104C475A31303330363636303038323132060081684406008E0E2646B57E107B017C16
2026-07-14T09:58:13.865Z gplugm01/debug [0;38m[VV][dlms_meter:030]: ============
```


This pull request makes the HDLC parser ignore MBus short packets.